### PR TITLE
Support Set. Flatten priority logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Takes any input and guarantees an array back.
 > arrayify([ 1, 2 ])
 [ 1, 2 ]
 
+> arrayify(new Set([ 1, 2 ]))
+[ 1, 2 ]
+
 > function f(){ return arrayify(arguments); }
 > f(1,2,3)
 [ 1, 2, 3 ]

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@
 ## array-back
 Takes any input and guarantees an array back.
 
-- converts array-like objects (e.g. `arguments`) to a real array
+- converts array-like objects (e.g. `arguments`, `Set`) to a real array
 - converts `undefined` to an empty array
-- converts any another other, singular value (including `null`) into an array containing that value
+- converts any another other, singular value (including `null`, objects and other iterables) into an array containing that value
 - ignores input which is already an array
 
-**Example**  
+**Example**
 ```js
 > const arrayify = require('array-back')
 

--- a/dist/test.js
+++ b/dist/test.js
@@ -50,15 +50,17 @@ function isArrayLike (input) {
 function arrayify (input) {
   if (Array.isArray(input)) {
     return input
-  } else {
-    if (input === undefined) {
-      return []
-    } else if (isArrayLike(input)) {
-      return Array.from(input)
-    } else {
-      return [ input ]
-    }
   }
+
+  if (input === undefined) {
+    return []
+  }
+
+  if (isArrayLike(input)) {
+    return Array.from(input)
+  }
+
+  return [ input ]
 }
 
 const runner = new TestRunner();
@@ -80,4 +82,10 @@ runner.test('arrayify()', function () {
     a.deepStrictEqual(arrayify(arguments), [ 1, 2, 3 ]);
   }
   func(1, 2, 3);
+
+  a.deepStrictEqual(arrayify({one: 1}), [ {one: 1} ]);
+  const map = new Map();
+  map.set('one', 1);
+  map.set('two', 2);
+  a.deepStrictEqual(arrayify(map), [ map ]);
 });

--- a/dist/test.js
+++ b/dist/test.js
@@ -39,7 +39,7 @@ function isObject (input) {
 }
 
 function isArrayLike (input) {
-  return isObject(input) && typeof input.length === 'number'
+  return isObject(input) && typeof input.length === 'number' || input instanceof Set
 }
 
 /**
@@ -54,7 +54,7 @@ function arrayify (input) {
     if (input === undefined) {
       return []
     } else if (isArrayLike(input)) {
-      return Array.prototype.slice.call(input)
+      return Array.from(input)
     } else {
       return [ input ]
     }
@@ -74,6 +74,7 @@ runner.test('arrayify()', function () {
   a.deepStrictEqual(arrayify(null), [ null ]);
   a.deepStrictEqual(arrayify(0), [ 0 ]);
   a.deepStrictEqual(arrayify([ 1, 2 ]), [ 1, 2 ]);
+  a.deepStrictEqual(arrayify(new Set([ 1, 2 ])), [ 1, 2 ]);
 
   function func () {
     a.deepStrictEqual(arrayify(arguments), [ 1, 2, 3 ]);

--- a/index.mjs
+++ b/index.mjs
@@ -32,7 +32,7 @@ function isObject (input) {
 }
 
 function isArrayLike (input) {
-  return isObject(input) && typeof input.length === 'number'
+  return isObject(input) && typeof input.length === 'number' || input instanceof Set
 }
 
 /**
@@ -43,15 +43,17 @@ function isArrayLike (input) {
 function arrayify (input) {
   if (Array.isArray(input)) {
     return input
-  } else {
-    if (input === undefined) {
-      return []
-    } else if (isArrayLike(input)) {
-      return Array.prototype.slice.call(input)
-    } else {
-      return [ input ]
-    }
   }
+
+  if (input === undefined) {
+    return []
+  }
+
+  if (isArrayLike(input)) {
+    return Array.from(input)
+  }
+
+  return [ input ]
 }
 
 export default arrayify

--- a/test.mjs
+++ b/test.mjs
@@ -15,6 +15,7 @@ runner.test('arrayify()', function () {
   a.deepStrictEqual(arrayify(null), [ null ])
   a.deepStrictEqual(arrayify(0), [ 0 ])
   a.deepStrictEqual(arrayify([ 1, 2 ]), [ 1, 2 ])
+  a.deepStrictEqual(arrayify(new Set([ 1, 2 ])), [ 1, 2 ])
 
   function func () {
     a.deepStrictEqual(arrayify(arguments), [ 1, 2, 3 ])

--- a/test.mjs
+++ b/test.mjs
@@ -21,4 +21,10 @@ runner.test('arrayify()', function () {
     a.deepStrictEqual(arrayify(arguments), [ 1, 2, 3 ])
   }
   func(1, 2, 3)
+
+  a.deepStrictEqual(arrayify({one: 1}), [ {one: 1} ])
+  const map = new Map();
+  map.set('one', 1);
+  map.set('two', 2);
+  a.deepStrictEqual(arrayify(map), [ map ])
 })


### PR DESCRIPTION
- Set has no `.length` but `.size` - Detect if instanceof Set
- Use [`Array.from`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from) to allow conversion of [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set)
- Flatten some if-else logic. Now the order of appearance is the order of priority.